### PR TITLE
 Add ReturnTypeWillChange attribut for PHP 8.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 ### master
 
+- Add #[\ReturnTypeWillChange] when needed to remove a new deprecated with PHP 8.1
+
 ### [3.3.1](../../compare/3.3.0...3.3.1) - 2021-09-11
 
 - Fix `composer require` version in `README.md` in GitHub Actions workflow `Release`

--- a/src/AbstractTypedArray.php
+++ b/src/AbstractTypedArray.php
@@ -64,6 +64,7 @@ abstract class AbstractTypedArray implements TypedArrayInterface, ReadOnlyInterf
     }
 
     /** @return string|int|null */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->valid() ? key($this->values) : null;
@@ -80,6 +81,7 @@ abstract class AbstractTypedArray implements TypedArrayInterface, ReadOnlyInterf
     }
 
     /** @return mixed */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $return = current($this->values);
@@ -129,6 +131,7 @@ abstract class AbstractTypedArray implements TypedArrayInterface, ReadOnlyInterf
      * @param mixed $offset
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if ($this->offsetExists($offset) === false) {


### PR DESCRIPTION
To remove this kind of deprecated:
`Deprecated: Return type of steevanb\PhpTypedArray\AbstractTypedArray::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /composer/vendor/steevanb/php-typed-array/src/AbstractTypedArray.php on line 132`